### PR TITLE
Please add suport for privacy API

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -1,0 +1,48 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Privacy Subsystem implementation for qbehaviour_deferredfeedbackexplain.
+ *
+ * @package    qbehaviour_deferredfeedbackexplain
+ * @copyright  2018 German Valero <gvalero@unam.mx>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace qbehaviour_deferredfeedbackexplain\privacy;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Privacy Subsystem for qbehaviour_deferredfeedbackexplain implementing null_provider.
+ *
+ * @copyright   2018 German Valero <gvalero@uam.mx>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class provider implements \core_privacy\local\metadata\null_provider {
+
+    use \core_privacy\local\legacy_polyfill;
+
+    /**
+     * Get the language string identifier with the component's language
+     * file to explain why this plugin stores no data.
+     *
+     * @return  string
+     */
+    public static function _get_reason() {
+        return 'privacy:metadata';
+    }
+}

--- a/lang/en/qbehaviour_deferredfeedbackexplain.php
+++ b/lang/en/qbehaviour_deferredfeedbackexplain.php
@@ -24,4 +24,5 @@
 
 $string['pleaseexplain'] = 'Give your reasons';
 $string['pluginname'] = 'Deferred feedback with explanation';
+$string['privacy:metadata'] = 'The Deferred feedback with explanation question behaviour plugin does not store any personal data.';
 $string['responsewithreason'] = '{$a->response} | Reason: {$a->explanation}';

--- a/version.php
+++ b/version.php
@@ -24,12 +24,12 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2018021600;
-$plugin->requires  = 2016120500;
+$plugin->version   = 2018062601; // The current plugin version (Date: YYYYMMDDXX).
+$plugin->requires  = 2016120500; // 2016120500 is Moodle 3.2.0 .
 $plugin->cron      = 0;
 $plugin->component = 'qbehaviour_deferredfeedbackexplain';
 $plugin->maturity  = MATURITY_STABLE;
-$plugin->release   = 'Version 1.1 for Moodle 3.2+';
+$plugin->release   = 'Version 1.2 for Moodle 3.2+';
 
 $plugin->dependencies = array(
     'qbehaviour_deferredfeedback' => 2016120500


### PR DESCRIPTION
Hi,

I know you are tremendously busy making great Moodle improvements and might not have the time for tiny "cosmetic" changes in your many Moodle additional plugins theat many of us enjoy.

I made some minor changes in order to add support for the Moodle 3.5 privacy API.

This removes the "This plugin does not implement the Moodle privacy API. If this plugin stores any personal data it will not be able to be exported or deleted through Moodle's privacy system." notice when checking the page at http://your_server/admin/tool/dataprivacy/pluginregistry.php?lang=en .

I hope I did not make any coding error.

Shall I go and make small changes to other similar plugins ?

Thanks in advance.
